### PR TITLE
nicknames & pfps

### DIFF
--- a/src/state/useNicknameStore.ts
+++ b/src/state/useNicknameStore.ts
@@ -1,0 +1,60 @@
+import { isValidPatp } from 'urbit-ob'
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import Urbit from "@uqbar/react-native-api"
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+import { resetSubscriptions } from "./util"
+
+import { ONE_SECOND } from "../util/time"
+import { isWeb } from '../constants/Layout'
+import { DefaultStore } from "./types/types";
+
+export interface NicknameStore  { // extends DefaultStore
+  loading: string | null;
+  api: Urbit | null
+  connected: boolean;
+
+  niccbook: Ships;
+  init: (api: Urbit, clearState?: boolean) => Promise<void>
+
+  //  clearSubscriptions: () => Promise<void>
+  //  refresh: (shipUrl: string) => Promise<void>;
+
+}
+// nickbook
+export interface Ships {
+  [ship: string]: [name: string, uri: string, item: string];
+}
+
+
+const useNicknameStore = create(
+  persist<NicknameStore>(
+    (set, get) => ({
+      loading: null,
+      api: null,
+      connected: true,
+
+      niccbook: {},
+
+      init: async (api: Urbit, clearState = false) => {
+        set({ api })
+        
+        // init empty sub to %nimi, scry out initial nickbook
+        const ships = await api.scry<{ 'ships': Ships }>({ app: 'nimi', path: '/niccbook' })
+        console.log('init ships: ', ships)
+
+        
+        // something to think about, maybe in %pokur, when a new table is joined (/chat), scry for nicks, 
+        // and for the ones we do not find, we can poke %nimi to check for them via %whodis pokes. 
+      },
+      set
+    }),
+    {
+      name: 'nicknames',   // necessary or pongo?
+      storage: createJSONStorage(() => isWeb ? sessionStorage : AsyncStorage),
+    }
+  )
+);
+
+export default useNicknameStore;


### PR DESCRIPTION
4 Letter name will unfortunately probably change soon.. But here are some useful files

https://github.com/bitful-pannul/nimi/blob/master/desk/sur/nimi.hoon
https://github.com/bitful-pannul/nimi/blob/master/desk/app/nimi.hoon


Objective would to open an empty sub to /updates on launch, then scry out a map from ship => [name, uri, item-id] from /x/niccbook.

If we in a new chat/poker table find users that are not in our niccbook, we can poke %nimi with [%find-ships ships=(list ship)]

when pokebacks come in (if we find new ships), they'll be emitted as [%ship =ship name=@t uri=@t item=@ux] cards on /updates.

The discovery mechanism is subject to change and might be an issue if every time someones not in our addressbook we poke, remote scry should mitigate some of this. 